### PR TITLE
[CONNECT-155] Include name in alert.

### DIFF
--- a/cocci/occiserver.c
+++ b/cocci/occiserver.c
@@ -89,8 +89,17 @@ public	struct rest_response * occi_alert(
 		void * vptr,
 		struct rest_client * cptr, 
 		struct rest_response * rptr,
+		char * name,
 		int status, 
 		char * message, char * nature, 
+		char * agent, char * tls );
+
+private	struct rest_response * occi_alert_relay_impl(
+		void * vptr,
+		struct rest_client * cptr,
+		struct rest_response * rptr,
+		int status,
+		char * message, char * nature,
 		char * agent, char * tls );
 
 private	struct rest_response *  (*occi_alert_relay)(
@@ -99,7 +108,7 @@ private	struct rest_response *  (*occi_alert_relay)(
 		struct rest_response * rptr, 
 		int status, char * message, 
 		char * nature, 
-		char * agent, char * tls)=occi_alert;;
+		char * agent, char * tls)=&occi_alert_relay_impl;
 
 
 /*	---------------------------------------------------------	*/
@@ -1840,6 +1849,7 @@ public	struct rest_response * occi_alert(
 		void * vptr,
 		struct rest_client * cptr, 
 		struct rest_response * rptr,
+		char * name,
 		int status, 
 		char * message, char * nature, 
 		char * agent, char * tls )
@@ -1860,6 +1870,11 @@ public	struct rest_response * occi_alert(
 	struct	cordscript_element * lptr;
 	struct	cordscript_element * rvalue;
 	char	buffer[2048];
+
+	if (name == NULL)
+	{
+		name = "";
+	}
 
 	if (!( optr = vptr ))
 		return(rptr);
@@ -1886,6 +1901,7 @@ public	struct rest_response * occi_alert(
 	}
 
 	else if ((!(dptr=occi_request_element(qptr,"occi.alert.source"      , agent   ) ))
+	     ||  (!(dptr=occi_request_element(qptr,"occi.alert.name"        , name  ) ))
 	     ||  (!(dptr=occi_request_element(qptr,"occi.alert.nature"      , nature  ) ))
 	     ||  (!(dptr=occi_request_element(qptr,"occi.alert.status"      , ecode   ) ))
 	     ||  (!(dptr=occi_request_element(qptr,"occi.alert.created"     , etime   ) ))
@@ -1910,6 +1926,19 @@ public	struct rest_response * occi_alert(
 	}
 }
 
+/*	-------------------------------------------------------		*/
+/*		    	o c c i _ a l e r t				*/
+/*	-------------------------------------------------------		*/
+private	struct rest_response * occi_alert_relay_impl(
+		void * vptr,
+		struct rest_client * cptr,
+		struct rest_response * rptr,
+		int status,
+		char * message, char * nature,
+		char * agent, char * tls )
+{
+	return occi_alert(vptr, cptr, rptr, NULL, status, message, nature, agent, tls);
+}
 
 private	struct occi_category * append_category_list( struct occi_category * lptr, struct occi_category * cptr )
 {

--- a/occi/occi.h
+++ b/occi/occi.h
@@ -234,7 +234,8 @@ public	void	set_occi_alert_relay( struct rest_response *  (*relay)(
 public	struct rest_response *  occi_alert(
 		void * i, 
 		struct rest_client * cptr, 
-		struct rest_response * rptr, 
+		struct rest_response * rptr,
+		char *name,
 		int status, char * message, 
 		char * nature, 
 		char * agent, char * tls);

--- a/osprocci/osprocci.c
+++ b/osprocci/osprocci.c
@@ -154,17 +154,18 @@ private	struct rest_response *  osprocci_alert_relay(
 {
 	struct	rest_request * rptr;
 	char subject[2048];
+	char *name = NULL;
 
 	/* detect and convert REST Alerts */
 	/* ------------------------------ */
 	if ((!( agent )) || ( strcmp( agent, "REST" ) != 0 ))
-		return( occi_alert( i, cptr, aptr, status, message, nature, agent, tls ) );
+		return( occi_alert( i, cptr, aptr, name, status, message, nature, agent, tls ) );
 	else if ((!( aptr )) || (!( rptr = aptr->request )))
-		return( occi_alert( i, cptr, aptr, status, message, nature, agent, tls ) );
+		return( occi_alert( i, cptr, aptr, name, status, message, nature, agent, tls ) );
 	else
 	{
 		sprintf(subject,"%s %s %s",rptr->method,rptr->object,message);
-		return( occi_alert( i, cptr, aptr, status, subject, nature, "openstack", tls ) );
+		return( occi_alert( i, cptr, aptr, name, status, subject, nature, "openstack", tls ) );
 	}
 }
 


### PR DESCRIPTION
cocci/occiserver.c
Added: "occi_alert_relay_impl()"
Altered: "occi_alert()" to include "name" parameter; set global "occi_alert_relay" to "occi_alert_relay_impl".

occi/occi.h
Altered: "occi_alert()" to include "name" parameter.

osprocci/osprocci.c
Altered: "osprocci_alert_relay()" to pass "name" parameter to "occi_alert()".
