### PR TITLE
[CONNECT-263] Handle special characters in XML attributes.

### DIFF
--- a/coxml/document.c
+++ b/coxml/document.c
@@ -70,6 +70,10 @@ private	int	document_atb_value( struct xml_application * xptr, char * token )
 		return( 48 );
 	else if (!( aptr->value = allocate_string( token ) ))
 		return( 27 );
+	else if (! (aptr->value = unserialize_xml_string_attribute_value(aptr->value)))
+	{
+		return ( 27 );
+	}
 	else	return(0);
 }
 

--- a/coxml/xmlparse.h
+++ b/coxml/xmlparse.h
@@ -93,6 +93,12 @@ struct	xml_parser	{
 /*	--------------------------	*/
 int	xml_parse( char * filename, struct xml_relay * interfaceitem, void * application );
 
+/* Attribute handling. */
+size_t translate_string_with_string(char const *input, char *buffer, int buffersize, char const *replace, char const *with);
+size_t translate_string_with_string_startpos(char const * startpos, char const *input, char *buffer, int buffersize, char const *replace, char const *with);
+void fprintf_xml_string_attribute(FILE *h, char const *format, char const *attribute);
+char * unserialize_xml_string_attribute_value(char *value);
+
 /*	--------------------------------------	*/
 /*	Call back functions for data retrieval	*/
 /*	--------------------------------------	*/

--- a/tools/strukt/occirest.c
+++ b/tools/strukt/occirest.c
@@ -318,20 +318,21 @@ void	generate_occi_rest_builder( FILE * h, char * nptr )
 			continue;
 		else
 		{
-		fprintf(h,"\t\tfprintf(h,%c %s=%cc%c,0x0022);\n",
-			0x0022,iptr->name,0x0025,0x0022);
-		if ( iptr->indirection )
-		{
-			fprintf(h,"\t\tfprintf(h,%c%cs%c,(pptr->%s?pptr->%s:%c%c));\n",
-				0x0022,0x0025,0x0022,iptr->name,iptr->name,0x0022,0x0022);
-		}
-		else
-		{
-			fprintf(h,"\t\tfprintf(h,%c%cu%c,pptr->%s);\n",
-				0x0022,0x0025,0x0022,iptr->name);
-		}
-		fprintf(h,"\t\tfprintf(h,%c%cc%c,0x0022);\n",
-			0x0022,0x0025,0x0022);
+			fprintf(h,"\t\tfprintf(h,%c %s=%cc%c,0x0022);\n",
+				0x0022,iptr->name,0x0025,0x0022);
+			if ( iptr->indirection )
+			{
+				fprintf(h, "\t\tfprintf_xml_string_attribute(h, \"%%s\", (pptr->%s?pptr->%s:\"\"));\n",
+					iptr->name, iptr->name
+				);
+			}
+			else
+			{
+				fprintf(h,"\t\tfprintf(h,%c%cu%c,pptr->%s);\n",
+					0x0022,0x0025,0x0022,iptr->name);
+			}
+			fprintf(h,"\t\tfprintf(h,%c%cc%c,0x0022);\n",
+				0x0022,0x0025,0x0022);
 		}
 	}
 


### PR DESCRIPTION
Convert double quote to &quot; on autosave,
and convert &quot; to double quote when parsing XML attribute values.

coxml/document.c
Altered: "document_atb_value()" to unserialize xml string attribute value.

coxml/xmlparse.c
Replaced (unused) Mnemonichs with character literals to avoid text editor issues.
Added: "translate_string_with_string_impl()", "translate_string_with_string()", "translate_string_with_string_startpos()";
"fprintf_xml_string_attribute()"; "unserialize_xml_string_attribute_value()".

coxml/xmlparse.h
Added: "translate_string_with_string()", "translate_string_with_string_startpos()";
"fprintf_xml_string_attribute()"; "unserialize_xml_string_attribute_value()".

tools/strukt/occirest.c
Altered: "generate_occi_rest_builder()" to call "fprintf_xml_string_attribute()" when writing out xml attribute strings.
